### PR TITLE
Handling array args

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,8 +8,13 @@
 'use strict';
 
 var path = require('path');
+var extend = require('extend-shallow');
 
 module.exports = function loader(file, opts) {
+  if (Array.isArray(file)) {
+    opts = extend({}, opts, file[1]);
+    file = file[0];
+  }
   var key = renameKey(file.path, opts);
   var template = {};
   template[key] = normalize(file, opts);

--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
     "loader",
     "template",
     "templateloader"
-  ]
+  ],
+  "dependencies": {
+    "extend-shallow": "^0.2.0"
+  }
 }

--- a/test.js
+++ b/test.js
@@ -21,5 +21,46 @@ describe('loader', function () {
     loader(a).README.should.have.property.base;
     loader(a).README.should.have.property.cwd;
   });
+
+  it('should accept array as first argument', function () {
+    var a = new File({path: 'README.md', contents: null});
+    var opts = {};
+    loader([a, opts]).should.have.property.README;
+    loader([a, opts]).README.should.have.property.contents;
+    loader([a, opts]).README.should.have.property.relative;
+    loader([a, opts]).README.should.have.property.base;
+    loader([a, opts]).README.should.have.property.cwd;
+  });
+
+  it('should use custom renameKey', function () {
+    var a = new File({path: 'README.md', contents: null});
+    var opts = {
+      renameKey: function (fp) {
+        return fp;
+      }
+    };
+    loader([a, opts]).should.have.property['README.md'];
+    loader([a, opts])['README.md'].should.have.property.contents;
+    loader([a, opts])['README.md'].should.have.property.relative;
+    loader([a, opts])['README.md'].should.have.property.base;
+    loader([a, opts])['README.md'].should.have.property.cwd;
+  });
+
+  it('should use custom normalize', function () {
+    var a = new File({path: 'README.md', contents: null});
+    var opts = {
+      normalize: function (file, opts) {
+        file.foo = 'bar';
+        return file;
+      }
+    };
+    loader([a, opts]).should.have.property.README;
+    loader([a, opts]).README.should.have.property.contents;
+    loader([a, opts]).README.should.have.property.relative;
+    loader([a, opts]).README.should.have.property.base;
+    loader([a, opts]).README.should.have.property.cwd;
+    loader([a, opts]).README.should.have.property.foo;
+    loader([a, opts]).README.foo.should.eql('bar');
+  });
 });
 


### PR DESCRIPTION
Since loaders can only take in a single argument, template passes multiple arguments as an array in the first parameter when multiple are specified.

Updating to handle multiple (from template-init) and adding tests.
